### PR TITLE
Remove dependencies on display if disabled

### DIFF
--- a/src/BootstrapManager.cpp
+++ b/src/BootstrapManager.cpp
@@ -232,7 +232,7 @@ void BootstrapManager::getMicrocontrollerInfo() {
 
 // Draw screensaver useful for OLED displays
 void BootstrapManager::drawScreenSaver(String txt) {
-
+#if (DISPLAY_ENABLED)
   if (screenSaverTriggered) {
     display.clearDisplay();
     for (int i = 0; i < 50; i++) {
@@ -248,12 +248,12 @@ void BootstrapManager::drawScreenSaver(String txt) {
     display.setTextColor(WHITE);
     screenSaverTriggered = false;
   }
-
+#endif
 }
 
 // draw some infos about your controller
 void BootstrapManager::drawInfoPage(String softwareVersion, String author) {
-
+#if (DISPLAY_ENABLED)
   yoffset -= 1;
   // add/remove 8 pixel for every line yoffset <= -209, if you want to add a line yoffset <= -217
   if (yoffset <= -209) {
@@ -280,7 +280,7 @@ void BootstrapManager::drawInfoPage(String softwareVersion, String author) {
 
   // add/remove 8 pixel for every line effectiveOffset+175, if you want to add a line effectiveOffset+183
   display.drawBitmap((((display.width()/2)-(ARDUINOLOGOW/2))), effectiveOffset+175, ARDUINOLOGO, ARDUINOLOGOW, ARDUINOLOGOH, 1);
-
+#endif
 }
 
 // send the state of your controller to the mqtt queue
@@ -346,11 +346,11 @@ DynamicJsonDocument BootstrapManager::readLittleFS(String filename) {
   // Helpers classes
   Helpers helper;
 
-  if (PRINT_TO_DISPLAY) {
+  #if (DISPLAY_ENABLED) 
     display.clearDisplay();
     display.setCursor(0, 0);
     display.setTextSize(1);
-  }
+  #endif
   helper.smartPrintln(F("Mounting LittleFS..."));
   helper.smartDisplay();
 
@@ -427,11 +427,11 @@ DynamicJsonDocument BootstrapManager::readSPIFFS(String filename) {
   // Helpers classes
   Helpers helper;
 
-  if (PRINT_TO_DISPLAY) {
+  #if (DISPLAY_ENABLED) 
     display.clearDisplay();
     display.setCursor(0, 0);
     display.setTextSize(1);
-  }
+  #endif
   helper.smartPrintln(F("Mounting SPIFSS..."));
   helper.smartDisplay();
   // SPIFFS.remove("/config.json");

--- a/src/BootstrapManager.h
+++ b/src/BootstrapManager.h
@@ -24,7 +24,6 @@
 #include <ArduinoJson.h>
 #include <SPI.h>
 #include <Wire.h>
-#include <Adafruit_SSD1306.h>
 #include <FS.h>
 #if defined(ESP8266)
   #include <LittleFS.h>

--- a/src/Configuration.cpp
+++ b/src/Configuration.cpp
@@ -19,6 +19,7 @@
 
 #include "Configuration.h"
 
-
+#if (DISPLAY_ENABLED)
 // Initialize the display
 Adafruit_SSD1306 display(SCREEN_WIDTH, SCREEN_HEIGHT, &Wire, OLED_RESET); 
+#endif

--- a/src/Configuration.h
+++ b/src/Configuration.h
@@ -31,7 +31,6 @@
   #include <HTTPClient.h>
   #include <WebServer.h>
 #endif
-#include <Adafruit_SSD1306.h>
 
 #ifndef AUTHOR
 #define AUTHOR "DPsoftware"
@@ -48,15 +47,17 @@
 
 // Specify if you want to use a display or only Serial
 #ifndef DISPLAY_ENABLED
-#define DISPLAY_ENABLED false;
+#define DISPLAY_ENABLED false
 #endif
-const bool PRINT_TO_DISPLAY = DISPLAY_ENABLED;
 
+#if (DISPLAY_ENABLED)
+#include <Adafruit_SSD1306.h>
 // Display specs
 #define OLED_RESET LED_BUILTIN // Pin used for integrated D1 Mini blue LED
 #define SCREEN_WIDTH 128 // OLED display width, in pixels
 #define SCREEN_HEIGHT 64 // OLED display height, in pixels
 extern Adafruit_SSD1306 display;
+#endif
 
 // SENSORNAME will be used as device network name
 #ifndef WIFI_DEVICE_NAME

--- a/src/Helpers.cpp
+++ b/src/Helpers.cpp
@@ -59,49 +59,49 @@ bool fastDisconnectionManagement = false;
 
 void Helpers::smartPrint(String msg) {
 
-  if (PRINT_TO_DISPLAY) {
+  #if (DISPLAY_ENABLED) 
     display.print(msg);
-  } else {
+  #else
     Serial.print(msg);
-  }
+  #endif
 
 }
 
 void Helpers::smartPrintln(String msg) {
 
-  if (PRINT_TO_DISPLAY) {
-    display.println(msg);
-  } else {
-    Serial.println(msg);
-  }
+  #if (DISPLAY_ENABLED) 
+    display.print(msg);
+  #else
+    Serial.print(msg);
+  #endif
 
 }
 
 void Helpers::smartPrint(int msg) {
 
-  if (PRINT_TO_DISPLAY) {
+  #if (DISPLAY_ENABLED) 
     display.print(msg);
-  } else {
+  #else
     Serial.print(msg);
-  }
+  #endif
 
 }
 
 void Helpers::smartPrintln(int msg) {
 
-  if (PRINT_TO_DISPLAY) {
-    display.println(msg);
-  } else {
-    Serial.println(msg);
-  }
+  #if (DISPLAY_ENABLED) 
+    display.print(msg);
+  #else
+    Serial.print(msg);
+  #endif
 
 }
 
 void Helpers::smartDisplay() {
 
-  if (PRINT_TO_DISPLAY) {
+  #if (DISPLAY_ENABLED) 
     display.display();
-  }
+  #endif
     
 }
 

--- a/src/QueueManager.cpp
+++ b/src/QueueManager.cpp
@@ -44,11 +44,11 @@ void QueueManager::mqttReconnect(void (*manageDisconnections)(), void (*manageQu
   // Loop until we're reconnected
   while (!mqttClient.connected() && WiFi.status() == WL_CONNECTED) {
 
-    if (PRINT_TO_DISPLAY) {
+    #if (DISPLAY_ENABLED) 
       display.clearDisplay();
       display.setTextSize(1);
       display.setCursor(0,0);
-    }
+    #endif
     if (mqttReconnectAttemp <= 20) {
       helper.smartPrintln(F("Connecting to"));
       helper.smartPrintln(F("MQTT Broker..."));

--- a/src/WifiManager.cpp
+++ b/src/WifiManager.cpp
@@ -41,21 +41,21 @@ void WifiManager::setupWiFi(void (*manageDisconnections)(), void (*manageHardwar
   wifiReconnectAttemp = 0;
 
   // DPsoftware domotics
-  if (PRINT_TO_DISPLAY) {
+  #if (DISPLAY_ENABLED) 
     display.clearDisplay();
     display.setTextSize(2);
     display.setCursor(5,17);
     display.drawRoundRect(0, 0, display.width()-1, display.height()-1, display.height()/4, WHITE);
-  }
+  #endif
   helper.smartPrintln(F("DPsoftware domotics"));
   helper.smartDisplay();
   delay(DELAY_3000);
 
-  if (PRINT_TO_DISPLAY) {
+  #if (DISPLAY_ENABLED) 
     display.clearDisplay();
     display.setTextSize(1);
     display.setCursor(0,0);
-  }
+  #endif
   helper.smartPrintln(F("Connecting to: "));
   helper.smartPrint(qsid); helper.smartPrintln(F("..."));
   helper.smartDisplay();
@@ -139,11 +139,11 @@ void WifiManager::reconnectToWiFi(void (*manageDisconnections)(), void (*manageH
       if (fastDisconnectionManagement) {
         manageDisconnections();
       }
-      if (PRINT_TO_DISPLAY) {
+      #if (DISPLAY_ENABLED) 
         display.setCursor(0,0);
         display.clearDisplay();
         display.setTextSize(1);
-      }
+      #endif
       helper.smartPrint(F("Wifi attemps= "));
       helper.smartPrintln(wifiReconnectAttemp);
       if (wifiReconnectAttemp >= MAX_RECONNECT) {


### PR DESCRIPTION
I am mostly using the boots trapper without an attached display. So if I compile without the display enabled, I want to make sure that I do not need any of the headers and the display library in my project.

