### PR TITLE
Fix dns issue esp32

### DIFF
--- a/src/Configuration.h
+++ b/src/Configuration.h
@@ -79,19 +79,26 @@ const double WIFI_POWER = WIFI_SIGNAL_STRENGTH;
 
 // GATEWAY IP
 #ifndef GATEWAY_IP
-#define GATEWAY_IP "192.168.1.1"
+#define GATEWAY_IP "192.168.1.1"   // entre your gateway IP address
 #endif
 const char* const IP_GATEWAY = GATEWAY_IP;
 
 // SUBNET IP
 #ifndef SUBNET_IP
-#define SUBNET_IP "192.168.1.1"
+#define SUBNET_IP "255.255.255.0"
 #endif
 const char* const IP_SUBNET = SUBNET_IP;
 
+// DNS IP
+#ifndef DNS_IP
+#define DNS_IP "8.8.8.8"    // enter a DNS server IP if you need domain name access and static IP is selected
+// example: 8.8.8.8 for Google DNS server or use the DNS server provided by your ISP (see your gateway configuration)
+#endif
+const char* const IP_DNS = DNS_IP;
+
 // STATIC IP FOR THE MICROCONTROLLER
 #ifndef MICROCONTROLLER_IP
-#define MICROCONTROLLER_IP "192.168.1.99"
+#define MICROCONTROLLER_IP "192.168.1.99"  // enter a valid IP address for static IP or "DHCP" for dynamic IP
 #endif
 const char* const IP_MICROCONTROLLER = MICROCONTROLLER_IP;
 

--- a/src/Configuration.h
+++ b/src/Configuration.h
@@ -79,7 +79,7 @@ const double WIFI_POWER = WIFI_SIGNAL_STRENGTH;
 
 // GATEWAY IP
 #ifndef GATEWAY_IP
-#define GATEWAY_IP "192.168.1.1"   // entre your gateway IP address
+#define GATEWAY_IP "192.168.1.1"   // enter your gateway IP address
 #endif
 const char* const IP_GATEWAY = GATEWAY_IP;
 

--- a/src/WifiManager.cpp
+++ b/src/WifiManager.cpp
@@ -48,8 +48,7 @@ void WifiManager::setupWiFi(void (*manageDisconnections)(), void (*manageHardwar
     display.drawRoundRect(0, 0, display.width()-1, display.height()-1, display.height()/4, WHITE);
   #endif
   helper.smartPrintln(F("DPsoftware domotics"));
-  helper.smartDisplay();
-  delay(DELAY_3000);
+  helper.smartDisplay(DELAY_3000);
 
   #if (DISPLAY_ENABLED) 
     display.clearDisplay();
@@ -58,9 +57,7 @@ void WifiManager::setupWiFi(void (*manageDisconnections)(), void (*manageHardwar
   #endif
   helper.smartPrintln(F("Connecting to: "));
   helper.smartPrint(qsid); helper.smartPrintln(F("..."));
-  helper.smartDisplay();
-
-  delay(DELAY_2000);
+  helper.smartDisplay(DELAY_2000);
 
   WiFi.persistent(true);   // Solve possible wifi init errors (re-add at 6.2.1.16 #4044, #4083)
   WiFi.disconnect(true);    // Delete SDK wifi config
@@ -71,7 +68,7 @@ void WifiManager::setupWiFi(void (*manageDisconnections)(), void (*manageHardwar
 #endif
   WiFi.setAutoConnect(true);
   WiFi.setAutoReconnect(true);
-  if (!microcontrollerIP.equals("DHCP")) {
+  if (!microcontrollerIP.equals("DHCP")) { 
     WiFi.config(IPAddress(helper.getValue(microcontrollerIP, '.', 0).toInt(),
                           helper.getValue(microcontrollerIP, '.', 1).toInt(),
                           helper.getValue(microcontrollerIP, '.', 2).toInt(),
@@ -84,6 +81,11 @@ void WifiManager::setupWiFi(void (*manageDisconnections)(), void (*manageHardwar
                           helper.getValue(IP_SUBNET, '.', 1).toInt(),
                           helper.getValue(IP_SUBNET, '.', 2).toInt(),
                           helper.getValue(IP_SUBNET, '.', 3).toInt()));
+                IPAddress(helper.getValue(IP_DNS, '.', 0).toInt(),
+                          helper.getValue(IP_DNS, '.', 1).toInt(),
+                          helper.getValue(IP_DNS, '.', 2).toInt(),
+                          helper.getValue(IP_DNS, '.', 3).toInt()));
+    
     Serial.println(F("Using static IP address"));
     dhcpInUse = false;
   } else {

--- a/src/WifiManager.cpp
+++ b/src/WifiManager.cpp
@@ -68,7 +68,7 @@ void WifiManager::setupWiFi(void (*manageDisconnections)(), void (*manageHardwar
 #endif
   WiFi.setAutoConnect(true);
   WiFi.setAutoReconnect(true);
-  if (!microcontrollerIP.equals("DHCP")) { 
+  if (!microcontrollerIP.equals("DHCP")) {
     WiFi.config(IPAddress(helper.getValue(microcontrollerIP, '.', 0).toInt(),
                           helper.getValue(microcontrollerIP, '.', 1).toInt(),
                           helper.getValue(microcontrollerIP, '.', 2).toInt(),
@@ -80,12 +80,11 @@ void WifiManager::setupWiFi(void (*manageDisconnections)(), void (*manageHardwar
                 IPAddress(helper.getValue(IP_SUBNET, '.', 0).toInt(),
                           helper.getValue(IP_SUBNET, '.', 1).toInt(),
                           helper.getValue(IP_SUBNET, '.', 2).toInt(),
-                          helper.getValue(IP_SUBNET, '.', 3).toInt()));
+                          helper.getValue(IP_SUBNET, '.', 3).toInt()),
                 IPAddress(helper.getValue(IP_DNS, '.', 0).toInt(),
                           helper.getValue(IP_DNS, '.', 1).toInt(),
                           helper.getValue(IP_DNS, '.', 2).toInt(),
                           helper.getValue(IP_DNS, '.', 3).toInt()));
-    
     Serial.println(F("Using static IP address"));
     dhcpInUse = false;
   } else {
@@ -163,6 +162,8 @@ void WifiManager::reconnectToWiFi(void (*manageDisconnections)(), void (*manageH
     helper.smartPrint(F("\nWIFI CONNECTED\nIP Address: "));
     microcontrollerIP = WiFi.localIP().toString();
     helper.smartPrintln(microcontrollerIP);
+    helper.smartPrint(F("nb of attempts: "));
+    helper.smartPrintln(wifiReconnectAttemp);
   }
 
 }


### PR DESCRIPTION
- fix DNS issue with ESP32
- remove remaining unnecessary delays
- add printing of connecting attempts information (useful with poor WiFi link)
Tested on ESP32 platform with the use of static IP and DNS Google server.
Closes #10