### PR TITLE
fix pingESP issue with ESP32

### DIFF
--- a/src/PingESP.h
+++ b/src/PingESP.h
@@ -1,7 +1,19 @@
 /*
   PingESP.h - Utility class for pining the default gateway from ESP8266,
-  some routers isn't able to detect connected devices if there is no traffic over the internet or direct to the gateway.
+  some routers aren't able to detect connected devices if there is no traffic over the internet or direct to the gateway.
   This is helpful as a stay alive class, useful for not triggering security features on routers.
+  Usage:
+  - add the following declaration in your application header file:
+      #include "PingESP.h"
+      PingESP pingESP;
+  - use `pingESP.ping(WiFi.gatewayIP());` in your application code
+
+  For the ESP32:
+  - you need to install the ESP32Ping library from https://github.com/marian-craciunescu/ESP32Ping 
+  - add the following declaration in your application header file:
+      #include "PingESP.h"
+      PingClass pingESP;`
+  - use `pingESP.ping(WiFi.gatewayIP());` in your application code
 
   Copyright (C) 2020 - 2022  Davide Perini
 
@@ -19,18 +31,25 @@
   If not, see <https://opensource.org/licenses/MIT/>.
 */
 
-#if defined(ESP8266)
+#if defined(ESP8266)||(ESP32)
 
 #ifndef PingESP_H
 #define PingESP_H
 
 #include <Arduino.h>
+#if defined(ESP8266)
 #include <ESP8266WiFi.h>
 
 extern "C" {
 #include <ping.h>
 }
+#elif defined(ESP32)
+    #include <WiFi.h>
+    #include <ESP32Ping.h>
+    #include <ping.h>
+#endif 
 
+#if defined(ESP8266)
 class PingESP {
 public:
     PingESP();
@@ -42,6 +61,8 @@ protected:
     static byte pingCount, pingError, pingSuccess;
 };
 
+#endif // ESP8226
+
 #endif // PingESP_H
 
-#endif
+#endif // ESP8226 or ESP32


### PR DESCRIPTION
In pingESP.h
- add appropriate #include declarations for the ESP32 platform
- add guideline in the comments header for ESP8266 and ESP32 users
Tested successfully on the ESP32 platform.
You might choose to displace the pingESP guidelines in the README file of Bootstrapper repository.
Closes #7