### PR TITLE
add optional 'force OTA web server'

### DIFF
--- a/src/BootstrapManager.cpp
+++ b/src/BootstrapManager.cpp
@@ -30,7 +30,7 @@ void BootstrapManager::bootstrapSetup(void (*manageDisconnections)(), void (*man
   }
 #endif
 
-  if (isWifiConfigured()) {
+  if (isWifiConfigured() && !forceWebServer) {
     isConfigFileOk = true;
     // Initialize Wifi manager
     wifiManager.setupWiFi(manageDisconnections, manageHardwareButton);

--- a/src/Helpers.cpp
+++ b/src/Helpers.cpp
@@ -57,6 +57,7 @@ String ERROR = "ERROR";
 int wifiReconnectAttemp = 0;
 int mqttReconnectAttemp = 0;
 bool fastDisconnectionManagement = false;
+bool forceWebServer = false;
 
 void Helpers::smartPrint(String msg) {
 

--- a/src/Helpers.h
+++ b/src/Helpers.h
@@ -67,6 +67,7 @@ extern String ERROR;
 extern int wifiReconnectAttemp;
 extern int mqttReconnectAttemp;
 extern bool fastDisconnectionManagement;
+extern bool forceWebServer; // if set to true, forces the use of launchWebServerForOTAConfig - added by Pronoe on 02/03/2022
 
 const int DELAY_10 = 10;
 const int DELAY_50 = 50;


### PR DESCRIPTION
Uses an optional parameter `forceWebServer ` which, when set to `true`, activates the Web server for OTA configuration,  even if a valid WiFi configuration has already been set
This allows, for example, to modify, on request, the WiFi credentials by Web server,.
Functional tests OK with the following configurations:

- isWifiConfigured() = true  and forceWebServer = true
- isWifiConfigured() = true  and forceWebServer = false (usual state)
- isWifiConfigured() = false and forceWebServer = false

Configuration not tested:  isWifiConfigured() = false and forceWebServer = true
Close #9