### PR TITLE
Adds support for MQTT Last Will & Testament settings

### DIFF
--- a/examples/ChangeName.cpp
+++ b/examples/ChangeName.cpp
@@ -23,7 +23,8 @@
 void setup() {
 
   Serial.begin(SERIAL_RATE);
-
+  // Optional - setup MQTT last will & testament 
+  bootstrapManager.setMQTTWill("path/for/last/will/message","last will payload",lastWillQOS,lastWillRetain,cleanSession);
   bootstrapManager.bootstrapSetup(manageDisconnections, manageHardwareButton, callback);
   
   // ENTER YOUR CODE HERE

--- a/examples/ChangeName.h
+++ b/examples/ChangeName.h
@@ -33,6 +33,9 @@ BootstrapManager bootstrapManager;
 /************* MQTT TOPICS **************************/
 const char* CHANGE_ME_TOPIC = "tele/changeme/CHANGEME";
 const char* CHANGE_ME_JSON_TOPIC = "tele/changeme/CHANGEME_JSON";
+static int lastWillQOS = 1;
+boolean lastWillRetain = false;
+boolean cleanSession = false;
 
 
 /********************************** FUNCTION DECLARATION (NEEDED BY PLATFORMIO WHILE COMPILING CPP FILES) *****************************************/

--- a/src/BootstrapManager.cpp
+++ b/src/BootstrapManager.cpp
@@ -70,6 +70,11 @@ void BootstrapManager::bootstrapLoop(void (*manageDisconnections)(), void (*mana
 
 }
 
+/********************************** SET LAST WILL PARAMETERS IN THE Q MANAGER **********************************/
+void BootstrapManager::setMQTTWill(const char *topic, const char *payload, const int qos, boolean retain, boolean cleanSession){
+  queueManager.setMQTTWill(topic, payload, qos, retain, cleanSession);
+}
+
 /********************************** SEND A SIMPLE MESSAGE ON THE QUEUE **********************************/
 void BootstrapManager::publish(const char *topic, const char *payload, boolean retained) {
 

--- a/src/BootstrapManager.h
+++ b/src/BootstrapManager.h
@@ -51,6 +51,7 @@ class BootstrapManager {
     StaticJsonDocument<BUFFER_SIZE> parseHttpMsg(String payload, unsigned int length); // print the message arriving from HTTP
     void bootstrapSetup(void (*manageDisconnectionFunction)(), void (*manageHardwareButton)(), void (*callback)(char*, byte*, unsigned int)); // bootstrap setup()
     void bootstrapLoop(void (*manageDisconnectionFunction)(), void (*manageQueueSubscription)(), void (*manageHardwareButton)()); // bootstrap loop()
+    void setMQTTWill(const char *topic, const char *payload, const int qos, boolean retain, boolean cleanSession); // set the last will parameters for mqtt
     void publish(const char *topic, const char *payload, boolean retained); // send a message on the queue
     void publish(const char *topic, JsonObject objectToSend, boolean retained); // send a message on the queue
     void unsubscribe(const char *topic); // unsubscribe to a queue topic

--- a/src/Configuration.h
+++ b/src/Configuration.h
@@ -148,8 +148,6 @@ const char* const MQTT_PORT = MQTT_SERVER_PORT;
 #ifndef MQTT_USE_LAST_WILL
 #define MQTT_WILL_TOPIC 0
 #define MQTT_WILL_PAYLOAD 0
-// const char* MQTT_WILL_TOPIC = 0;
-// const char* MQTT_WILL_PAYLOAD = 0;
 #endif
 
 #ifndef MQTT_WILL_QOS

--- a/src/Configuration.h
+++ b/src/Configuration.h
@@ -144,24 +144,6 @@ const char* const MQTT_PORT = MQTT_SERVER_PORT;
 #define MQTT_KEEP_ALIVE 60
 #endif
 
-// MQTT Last Will
-#ifndef MQTT_USE_LAST_WILL
-#define MQTT_WILL_TOPIC 0
-#define MQTT_WILL_PAYLOAD 0
-#endif
-
-#ifndef MQTT_WILL_QOS
-#define MQTT_WILL_QOS 1
-#endif
-
-#ifndef MQTT_WILL_RETAIN
-#define MQTT_WILL_RETAIN 0
-#endif
-
-#ifndef MQTT_CLEAN_SESSION
-#define MQTT_CLEAN_SESSION 1
-#endif
-
 // Additional param that can be used for general purpose use
 #ifndef ADDITIONAL_PARAM_TEXT
 #define ADDITIONAL_PARAM_TEXT "ADDITIONAL PARAM"

--- a/src/Configuration.h
+++ b/src/Configuration.h
@@ -144,6 +144,26 @@ const char* const MQTT_PORT = MQTT_SERVER_PORT;
 #define MQTT_KEEP_ALIVE 60
 #endif
 
+// MQTT Last Will
+#ifndef MQTT_USE_LAST_WILL
+#define MQTT_WILL_TOPIC 0
+#define MQTT_WILL_PAYLOAD 0
+// const char* MQTT_WILL_TOPIC = 0;
+// const char* MQTT_WILL_PAYLOAD = 0;
+#endif
+
+#ifndef MQTT_WILL_QOS
+#define MQTT_WILL_QOS 1
+#endif
+
+#ifndef MQTT_WILL_RETAIN
+#define MQTT_WILL_RETAIN 0
+#endif
+
+#ifndef MQTT_CLEAN_SESSION
+#define MQTT_CLEAN_SESSION 1
+#endif
+
 // Additional param that can be used for general purpose use
 #ifndef ADDITIONAL_PARAM_TEXT
 #define ADDITIONAL_PARAM_TEXT "ADDITIONAL PARAM"

--- a/src/Helpers.cpp
+++ b/src/Helpers.cpp
@@ -42,11 +42,11 @@ String mqttIP = "XXX";
 String mqttPort = "XXX";
 String mqttuser = "XXX";
 String mqttpass = "XXX";
-String mqttWillTopic = "";
-String mqttWillPayload = "";
+String mqttWillTopic = "0";
+String mqttWillPayload = "0";
 int mqttWillQOS = 1;
 bool mqttWillRetain = 0;
-bool mqttCleanSession = 0;
+bool mqttCleanSession = 1;
 String additionalParam = "XXX";
 
 long previousMillis = 0;     

--- a/src/Helpers.cpp
+++ b/src/Helpers.cpp
@@ -42,6 +42,11 @@ String mqttIP = "XXX";
 String mqttPort = "XXX";
 String mqttuser = "XXX";
 String mqttpass = "XXX";
+String mqttWillTopic = "";
+String mqttWillPayload = "";
+int mqttWillQOS = 1;
+bool mqttWillRetain = 0;
+bool mqttCleanSession = 0;
 String additionalParam = "XXX";
 
 long previousMillis = 0;     

--- a/src/Helpers.h
+++ b/src/Helpers.h
@@ -51,6 +51,11 @@ extern String mqttIP;
 extern String mqttPort;
 extern String mqttuser;
 extern String mqttpass;
+extern String mqttWillTopic;
+extern String mqttWillPayload;
+extern int mqttWillQOS;
+extern bool mqttWillRetain;
+extern bool mqttCleanSession;
 extern String additionalParam;
 
 // Blink LED vars

--- a/src/QueueManager.cpp
+++ b/src/QueueManager.cpp
@@ -35,6 +35,15 @@ void QueueManager::setupMQTTQueue(void (*callback)(char*, byte*, unsigned int)) 
 
 }
 
+/********************************** SET LAST WILL PARAMETERS **********************************/
+void QueueManager::setMQTTWill(const char *topic, const char *payload, const int qos, boolean retain, boolean cleanSession){
+  mqttWillTopic = topic;
+  mqttWillPayload = payload;
+  mqttWillQOS = qos;
+  mqttWillRetain = retain;
+  mqttCleanSession = cleanSession;
+}
+
 /********************************** MQTT RECONNECT **********************************/
 void QueueManager::mqttReconnect(void (*manageDisconnections)(), void (*manageQueueSubscription)(), void (*manageHardwareButton)()) {
 
@@ -60,24 +69,23 @@ void QueueManager::mqttReconnect(void (*manageDisconnections)(), void (*manageQu
 
     // Attempt to connect to MQTT server with QoS = 1 (pubsubclient supports QoS 1 for subscribe only, published msg have QoS 0 this is why I implemented a custom solution)
     boolean mqttSuccess;
-#ifndef MQTT_USE_LAST_WILL
-	Serial.println("USE LAST WILL NOT DEFINED!!!!!");
-#endif
 
-#ifndef IMPROV_ENABLED
-	Serial.println("IMPROV ENABLED NOT DEFINED EITHER");
-#else
-	Serial.print("IMPROV ENABLED:");
-	Serial.println(IMPROV_ENABLED);
-#endif
-	
-	Serial.print("MQTT_WILL_TOPIC in QueueManager::mqttReconnect: ");
-	Serial.println(MQTT_WILL_TOPIC);
-	
+    Serial.println("MQTT Last Will Params: ");
+    Serial.print("willTopic: ");
+    Serial.println(mqttWillTopic);
+    Serial.print("willPayload: ");
+    Serial.println(mqttWillPayload);
+    Serial.print("qos: ");
+    Serial.println(mqttWillQOS);
+    Serial.print("retain: ");
+    Serial.println(mqttWillRetain);
+    Serial.print("clean session: ");
+    Serial.println(mqttCleanSession);
+
     if (mqttuser.isEmpty() || mqttpass.isEmpty()) {
-      mqttSuccess = mqttClient.connect(helper.string2char(deviceName), MQTT_WILL_TOPIC, MQTT_WILL_QOS, MQTT_WILL_RETAIN, MQTT_WILL_PAYLOAD);
+      mqttSuccess = mqttClient.connect(helper.string2char(deviceName), helper.string2char(mqttWillTopic), mqttWillQOS, mqttWillRetain, helper.string2char(mqttWillPayload));
     } else {
-      mqttSuccess = mqttClient.connect(helper.string2char(deviceName), helper.string2char(mqttuser), helper.string2char(mqttpass), MQTT_WILL_TOPIC, MQTT_WILL_QOS, MQTT_WILL_RETAIN, MQTT_WILL_PAYLOAD, MQTT_CLEAN_SESSION);
+      mqttSuccess = mqttClient.connect(helper.string2char(deviceName), helper.string2char(mqttuser), helper.string2char(mqttpass), helper.string2char(mqttWillTopic), mqttWillQOS, mqttWillRetain, helper.string2char(mqttWillPayload), mqttCleanSession);
     }
     if (mqttSuccess) {
 

--- a/src/QueueManager.cpp
+++ b/src/QueueManager.cpp
@@ -60,10 +60,24 @@ void QueueManager::mqttReconnect(void (*manageDisconnections)(), void (*manageQu
 
     // Attempt to connect to MQTT server with QoS = 1 (pubsubclient supports QoS 1 for subscribe only, published msg have QoS 0 this is why I implemented a custom solution)
     boolean mqttSuccess;
+#ifndef MQTT_USE_LAST_WILL
+	Serial.println("USE LAST WILL NOT DEFINED!!!!!");
+#endif
+
+#ifndef IMPROV_ENABLED
+	Serial.println("IMPROV ENABLED NOT DEFINED EITHER");
+#else
+	Serial.print("IMPROV ENABLED:");
+	Serial.println(IMPROV_ENABLED);
+#endif
+	
+	Serial.print("MQTT_WILL_TOPIC in QueueManager::mqttReconnect: ");
+	Serial.println(MQTT_WILL_TOPIC);
+	
     if (mqttuser.isEmpty() || mqttpass.isEmpty()) {
-      mqttSuccess = mqttClient.connect(helper.string2char(deviceName), 0, 1, 0, 0);
+      mqttSuccess = mqttClient.connect(helper.string2char(deviceName), MQTT_WILL_TOPIC, MQTT_WILL_QOS, MQTT_WILL_RETAIN, MQTT_WILL_PAYLOAD);
     } else {
-      mqttSuccess = mqttClient.connect(helper.string2char(deviceName), helper.string2char(mqttuser), helper.string2char(mqttpass), 0, 1, 0, 0, 1);
+      mqttSuccess = mqttClient.connect(helper.string2char(deviceName), helper.string2char(mqttuser), helper.string2char(mqttpass), MQTT_WILL_TOPIC, MQTT_WILL_QOS, MQTT_WILL_RETAIN, MQTT_WILL_PAYLOAD, MQTT_CLEAN_SESSION);
     }
     if (mqttSuccess) {
 

--- a/src/QueueManager.h
+++ b/src/QueueManager.h
@@ -31,6 +31,7 @@ class QueueManager {
 
   public:
     void setupMQTTQueue(void (*callback)(char*, byte*, unsigned int)); // setup the queue
+    void setMQTTWill(const char *topic, const char *payload, const int qos, boolean retain, boolean cleanSession); // set the last will parameters for mqtt
     void mqttReconnect(void (*manageDisconnections)(), void (*manageQueueSubscription)(), void (*manageHardwareButton)()); // manage reconnection on the queue
     void queueLoop(void (*manageDisconnections)(), void (*manageQueueSubscription)(), void (*manageHardwareButton)()); // manage queue loop 
     void publish(const char *topic, const char *payload, boolean retained); // send a message on the queue


### PR DESCRIPTION
Added a method for setting MQTT last will params. The new method is optional. Default values are used if not called which match the original params.