### PR TITLE
Add ESP32 working environment in PlatformIO.ini

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,25 +15,32 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install platformio
-        python --version         
-    - name: Install submodules 
-      run: |        
+        python --version
+    - name: Install submodules
+      run: |
         pwd
         git submodule update --init
         ls
     - name: Setup template config files
-      run: |                
+      run: |
         mkdir /home/runner/work/arduino_bootstrapper/arduino_bootstrapper/include
-        cp /home/runner/work/arduino_bootstrapper/arduino_bootstrapper/examples/ChangeName.cpp /home/runner/work/arduino_bootstrapper/arduino_bootstrapper/src/ChangeName.cpp    
-        cp /home/runner/work/arduino_bootstrapper/arduino_bootstrapper/examples/ChangeName.h /home/runner/work/arduino_bootstrapper/arduino_bootstrapper/include/ChangeName.h    
+        cp /home/runner/work/arduino_bootstrapper/arduino_bootstrapper/examples/ChangeName.cpp /home/runner/work/arduino_bootstrapper/arduino_bootstrapper/src/ChangeName.cpp
+        cp /home/runner/work/arduino_bootstrapper/arduino_bootstrapper/examples/ChangeName.h /home/runner/work/arduino_bootstrapper/arduino_bootstrapper/include/ChangeName.h
     # - name: Setup tmate session
     #   uses: mxschmitt/action-tmate@v3
     - name: Static code analysis
-      run: platformio check --verbose --severity=high --skip-packages                     
-    - name: Run PlatformIO
-      run: platformio run -e bootstrapper
+      run: platformio check --verbose --severity=high --skip-packages
+    - name: Run PlatformIO ESP8266
+      run: platformio run -e esp8266
     - name: Creating artifact from BIN file
       uses: actions/upload-artifact@v2
       with:
-        name: firmware_build_artifact_arduino_bootstrapper.bin
-        path: .pio/build/bootstrapper/firmware.bin
+        name: firmware_build_artifact_arduino_esp8266.bin
+        path: .pio/build/esp8266/firmware.bin
+    - name: Run PlatformIO ESP32
+      run: platformio run -e esp32
+    - name: Creating artifact from BIN file
+      uses: actions/upload-artifact@v2
+      with:
+        name: firmware_build_artifact_arduino_esp32.bin
+        path: .pio/build/esp32/firmware.bin

--- a/platformio.ini
+++ b/platformio.ini
@@ -10,28 +10,26 @@
 
 [platformio]
 extra_configs = secrets.ini
+default_envs = esp8266
 
-[env:bootstrapper]
-platform = espressif8266@4.0.1 ; for ESP32 use: espressif32
-platform_packages = platformio/framework-arduinoespressif8266 @ https://github.com/esp8266/Arduino.git#313b3c07ecccbe6fee24aa9fa447c4aed16ca499
-board = d1_mini ; for ESP32 Lolin D32 board use: lolin_d32
+[env]
 framework = arduino
 
-build_flags = 
-    '-D AUTHOR="DPsoftware"' 
-    '-D SERIAL_RATE=115200' 
+build_flags =
+    '-D AUTHOR="DPsoftware"'
+    '-D SERIAL_RATE=115200'
     '-D DEBUG_QUEUE_MSG=true'
     '-D DISPLAY_ENABLED=false'
     '-D WIFI_DEVICE_NAME="ArduinoBootstrapper"'
-    '-D MICROCONTROLLER_OTA_PORT=8199' 
-    '-D WIFI_SIGNAL_STRENGTH=0' 
+    '-D MICROCONTROLLER_OTA_PORT=8199'
+    '-D WIFI_SIGNAL_STRENGTH=0'
     '-D GATEWAY_IP="192.168.1.1"'
     '-D SUBNET_IP="192.168.1.1"'
     '-D MICROCONTROLLER_IP="192.168.1.99"'
     '-D MQTT_SERVER_IP="192.168.1.3"'
     '-D MQTT_SERVER_PORT="1883"'
-    '-D MAX_RECONNECT=500' 
-    '-D MAX_JSON_OBJECT_SIZE=50' 
+    '-D MAX_RECONNECT=500'
+    '-D MAX_JSON_OBJECT_SIZE=50'
     '-D MQTT_MAX_PACKET_SIZE=1024'
     '-D WIFI_SSID="${secrets.wifi_ssid}"'
     '-D WIFI_PWD="${secrets.wifi_password}"'
@@ -40,16 +38,27 @@ build_flags =
     '-D OTA_PWD="${secrets.ota_password}"'
     '-D ADDITIONAL_PARAM_TEXT="ADDITIONAL PARAM TEXT"'
 
-monitor_port = COM4
 monitor_speed = 115200
-monitor_filters = esp8266_exception_decoder ; for ESP32 use: esp32_exception_decoder
-board_build.f_cpu = 80000000L ; for ESP32 use: 240000000L, ESP8266 can run @160000000L if you need it
 ; upload_protocol = espota
 ; upload_port = 192.168.1.99
 ; upload_flags =
 ;     --port=8268
 ;     --auth=${secrets.ota_password} ; configure secrets.ini for OTA Upload, first upload using COM port is needed
-upload_port = COM4
-lib_deps =    
+lib_deps =
     ArduinoJson
     PubSubClient
+
+[env:esp8266]
+platform = espressif8266@4.0.1
+platform_packages = platformio/framework-arduinoespressif8266 @ https://github.com/esp8266/Arduino.git#313b3c07ecccbe6fee24aa9fa447c4aed16ca499
+board = d1_mini
+
+monitor_filters = esp8266_exception_decoder
+board_build.f_cpu = 80000000L
+
+[env:esp32]
+platform = espressif32@5.2.0
+board = lolin_d32
+
+monitor_filters = esp32_exception_decoder
+board_build.f_cpu = 240000000L


### PR DESCRIPTION
Thanks for the bootstrapper, it's already proving very useful! 

This change creates two separate working environments for ESP8266 & ESP32. Shared options are in the common `env` section and only the options that differ between each working environment need to be specified in the working sections. The original `bootstrapper` working environment is removed in favour of the more prescriptive ESP8266 & ESP32. 

This allows a user to easily choose which platform they are working with by using the [environment option](https://docs.platformio.org/en/latest/core/userguide/cmd_run.html#cmdoption-pio-run-e) on the command line or by changing the [`default_envs`](https://docs.platformio.org/en/latest/projectconf/section_platformio.html#projectconf-pio-default-envs) option in `platform.io`. When using the [VS Code add in for PlatformIO](https://marketplace.visualstudio.com/items?itemName=platformio.platformio-ide) you can also select the working environment in the status bar at the bottom.

![image](https://user-images.githubusercontent.com/6237786/200131072-475e72a0-7fcb-4e5f-8c4f-7e654e574632.png)
which then gives you options at the top of the IDE to choose when environment the project tasks will run in
![image](https://user-images.githubusercontent.com/6237786/200131098-837d070a-31fa-4071-a98c-7456bcb61982.png)

I hope this is a useful change. The `default_envs` option has been set to esp8266, so default behaviour is exactly the same as it was before. 
