### PR TITLE
Changing default Wifi power to max; Serial print power on startup

### DIFF
--- a/src/Configuration.h
+++ b/src/Configuration.h
@@ -78,7 +78,7 @@ const int OTA_PORT = MICROCONTROLLER_OTA_PORT;
 
 // Set wifi power in dbm range 0/0.25, set to 0 to reduce PIR false positive due to wifi power, 0 low, 20.5 max.
 #ifndef WIFI_SIGNAL_STRENGTH
-#define WIFI_SIGNAL_STRENGTH 0
+#define WIFI_SIGNAL_STRENGTH 20.5
 #endif
 const double WIFI_POWER = WIFI_SIGNAL_STRENGTH;
 

--- a/src/WifiManager.cpp
+++ b/src/WifiManager.cpp
@@ -103,6 +103,8 @@ void WifiManager::setupWiFi(void (*manageDisconnections)(), void (*manageHardwar
   WiFi.hostname(helper.string2char(deviceName));
   // Set wifi power in dbm range 0/0.25, set to 0 to reduce PIR false positive due to wifi power, 0 low, 20.5 max.
   WiFi.setOutputPower(WIFI_POWER);
+  Serial.print("Set WiFi output power to: ");
+  Serial.println(WIFI_POWER);
   if (microcontrollerIP.equals("DHCP")) {
     WiFi.config(0U, 0U, 0U);
   }


### PR DESCRIPTION
Having the default power set to the minimum level is a bit dangerous as the majority of people will never even realize the library is doing this (or even that there is an option to change the power level).

By setting the default to maximum we match the normal defaults. By printing the power level to the serial monitor, it offers a clue that the level is adjustable and that there is a build flag for changing the power level if someone wants to save power in their project.