### PR TITLE
Non blocking reconnect

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -23,6 +23,7 @@ build_flags =
     '-D DISPLAY_ENABLED=false'
     '-D WIFI_DEVICE_NAME="ArduinoBootstrapper"'
     '-D MICROCONTROLLER_OTA_PORT=8199' 
+    '-D NON_BLOCKING_RECONNECT=0'
     '-D WIFI_SIGNAL_STRENGTH=0' 
     '-D GATEWAY_IP="192.168.1.1"'
     '-D SUBNET_IP="192.168.1.1"'


### PR DESCRIPTION
This PR adds a build flag `NON_BLOCKING_RECONNECT` which allows you to enable non blocking wifi reconnects. When set to `0` the library behaves how it used to. When set to `1` the main `loop()` will continue to fire while the library attempts to re-establish the wifi connection.